### PR TITLE
New Travis setup for the Electron-based version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,13 @@ language: rust
 cache: cargo
 dist: xenial
 before_install:
-- sudo apt-get install libexpat-dev libfreetype6-dev libxcb-xkb-dev libfontconfig1-dev libgles2-mesa-dev
+  - curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update && sudo apt-get install yarn
 sudo: required
 before_script:
   - rustup component add rustfmt
 script:
-  - cargo fmt --all -- --check
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc --no-deps --document-private-items
-after_success: |
-  [ $TRAVIS_BRANCH = develop ] && # only do this on the develop branch
-  [ $TRAVIS_PULL_REQUEST = false ] && #only do this if it is not a pull request, should comment out to test after the token is added and before merging
-  echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
-  sudo pip install ghp-import &&
-  ghp-import -n target/doc &&
-  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+  - ./server/build.sh
+  - ./client/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-cache: cargo
+cache:
+  cargo: true
+  directories:
+    - $HOME/.yarn-cache
 dist: xenial
 before_install:
   - curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -

--- a/client/build.sh
+++ b/client/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd client
+yarn install &&
+yarn clean-check &&
+yarn build

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "electron .",
     "build": "webpack --progress --colors",
-    "clean": "yarn prettier --write \"src/**/*.js?(x)\" webpack.config.js"
+    "clean": "yarn prettier --write \"src/**/*.js?(x)\" webpack.config.js",
+    "clean-check": "yarn prettier --check \"src/**/*.js?(x)\" webpack.config.js"
   },
   "main": "main.js",
   "devDependencies": {

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd server
+cargo fmt --all -- --check &&
+cargo build --verbose &&
+cargo test --verbose

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,7 +23,8 @@ fn handle_request(req: Request<Body>) -> BoxFuture {
             //     }
             // });
             let mapping = req.into_body().map(|chunk| {
-                chunk.iter()
+                chunk
+                    .iter()
                     .map(|byte| {
                         println!("{}", *byte as char);
                         byte.to_ascii_uppercase()


### PR DESCRIPTION
## Proposed Changes
 - Move the build commands for client and server into separate scripts (build.sh)
 - Add commands to install Node.js and Yarn manually (since Travis does not support configuration for multiple languages natively)

## Related Stories
 - [Figure out how to effectively build the project with Travis CI](https://documentprocessor.atlassian.net/browse/DOCS-80)

## Acknowledgements
 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
 - [x] I have followed the branching requirements.
 - [x] I have run `rustfmt` on all proposed Rust.

Please review @sean0x42
