### PR TITLE
Include js files in root when running `yarn clean`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
  - And here...
 
 ## Acknowledgements
- - [ ] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
+ - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
  - [ ] I have followed the branching requirements.
- - [ ] I have run `rustfmt` on all proposed Rust.
+ - [ ] I have run `rustfmt` and `yarn clean` on all proposed Rust.
 
 Please review @sean0x42

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,6 @@
 ## Acknowledgements
  - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
  - [ ] I have followed the branching requirements.
- - [ ] I have run `rustfmt` and `yarn clean` on all proposed Rust.
+ - [ ] I have run `rustfmt` and `yarn clean` on all proposed Rust and JavaScript.
 
 Please review @sean0x42

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,6 @@
-const {app, BrowserWindow} = require("electron");
+/** @format */
+
+const { app, BrowserWindow } = require("electron");
 
 // Keep a global reference to the window object to prevent it from being
 // destroyed by the garbage collector.
@@ -10,11 +12,11 @@ function createWindow() {
     width: 800,
     webPreferences: {
       nodeIntegration: true,
-    }
+    },
   });
 
   mainWindow.loadFile("index.html");
-  mainWindow.on("closed", () => mainWindow = null);
+  mainWindow.on("closed", () => (mainWindow = null));
 }
 
 app.on("ready", createWindow);

--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "electron .",
     "build": "webpack --progress --colors",
-    "clean": "yarn prettier --write \"src/**/*.js?(x)\" webpack.config.js",
-    "clean-check": "yarn prettier --check \"src/**/*.js?(x)\" webpack.config.js"
+    "clean": "yarn prettier --write \"src/**/*.js?(x)\" *.js",
+    "clean-check": "yarn prettier --check \"src/**/*.js?(x)\" *.js"
   },
   "main": "main.js",
   "devDependencies": {


### PR DESCRIPTION
## Proposed Changes
 - Include all root `.js` files in yarn clean. Notably, this now includes `main.js` as well as `webpack.config.js`.
 - Add `yarn clean` requirement to pull request template.

## Acknowledgements
 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
 - [x] I have followed the branching requirements.
 - [x] I have run `rustfmt` and `yarn clean` on all proposed Rust.

Please review @sean0x42
