### PR TITLE
Added basic document implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 sudo: required
 before_script:
   - rustup component add rustfmt
+  - rustup component add clippy
 script:
   - ./server/build.sh
   - ./client/build.sh

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 [dependencies]
 zip = "0.5.2"
 xml-rs = "0.8.0"
-serde_json = "1.0.39"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tiny_http = "0.6.2"

--- a/server/build.sh
+++ b/server/build.sh
@@ -2,6 +2,6 @@
 
 cd server
 cargo fmt --all -- --check &&
-cargo clippy -- -D warnings &&
+cargo clippy &&
 cargo build --verbose &&
 cargo test --verbose

--- a/server/build.sh
+++ b/server/build.sh
@@ -2,5 +2,6 @@
 
 cd server
 cargo fmt --all -- --check &&
+cargo clippy -- -D warnings &&
 cargo build --verbose &&
 cargo test --verbose

--- a/server/src/document/mod.rs
+++ b/server/src/document/mod.rs
@@ -1,0 +1,40 @@
+pub mod node;
+pub mod units;
+
+use node::Node;
+use serde::{Deserialize, Serialize};
+use units::DistanceUnit;
+
+#[derive(Serialize, Deserialize)]
+pub struct PaperSize {
+    height: i32,
+    width: i32,
+    unit: DistanceUnit,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Document {
+    title: String,
+    paper_size: PaperSize,
+    pub children: Vec<Node>,
+}
+
+impl Document {
+    /// Constructs a new document object
+    ///
+    /// - `title` Document title.
+    /// - `paper_size` Document size.
+    pub fn new(title: String, paper_size: PaperSize) -> Document {
+        Document {
+            title,
+            paper_size,
+            children: Vec::new(),
+        }
+    }
+
+    /// Converts the document to a JSON string
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}

--- a/server/src/document/node.rs
+++ b/server/src/document/node.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Node {
+    Text(Text),
+    Element(Element),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Text {
+    content: String,
+}
+
+impl Text {
+    /// Constructs a new text node.
+    ///
+    ///  - `content`: Internal text content.
+    pub fn new(content: String) -> Text {
+        Text { content }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Element {
+    tag: String,
+    pub attributes: HashMap<String, String>,
+    pub styles: HashMap<String, String>,
+    pub children: Vec<Node>,
+}
+
+impl Element {
+    /// Constructs a new element
+    ///
+    /// - `tag`: Tag name.
+    pub fn new(tag: String) -> Element {
+        Element {
+            tag,
+            attributes: HashMap::new(),
+            styles: HashMap::new(),
+            children: Vec::new(),
+        }
+    }
+}

--- a/server/src/document/units.rs
+++ b/server/src/document/units.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub enum DistanceUnit {
+    Millimetres,
+    Centimetres,
+    Metres,
+    Inches,
+    Points,
+    Picas,
+    Pixels,
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,6 +3,8 @@ extern crate tiny_http;
 extern crate xml;
 extern crate zip;
 
+mod document;
+
 use serde_json::map::Map;
 use serde_json::value::Value;
 use serde_json::Number;


### PR DESCRIPTION
## Proposed Changes
 - Add a `Document` struct which can be serialized and deserialized into JSON. For now the struct is relatively barebones, but additional functionality can be added to make things such as traversing the tree easier (e.g. a DOM/Tree Walker).
 - Add [`clippy`](https://github.com/rust-lang/rust-clippy) to the project (a linter).

## Acknowledgements
 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
 - [x] I have followed the branching requirements.
 - [x] I have run `rustfmt` and `yarn clean` on all proposed Rust and JavaScript.

Note: More work will definitely need to be done to make the parser compatible with this PR. We'll be working towards that in #15 

