### PR TITLE
Replace xml-rs with quick-xml

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 zip = "0.5.2"
-xml-rs = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tiny_http = "0.6.2"
+quick-xml = "0.14.0"

--- a/server/src/parsers/odt.rs
+++ b/server/src/parsers/odt.rs
@@ -6,6 +6,7 @@ use crate::document::node::{Element, Node, Text};
 use crate::document::units::DistanceUnit;
 use crate::document::{Document, PaperSize};
 use std::collections::HashMap;
+use std::io::BufReader;
 use xml::reader::{EventReader, XmlEvent};
 
 pub struct ODTParser {
@@ -58,12 +59,13 @@ impl ODTParser {
             // Handle case where there is no content.xml (so probably not actually an ODT file)
             return Err(e.to_string());
         }
+        let content_xml = BufReader::new(content_xml.unwrap()); //add buffering because quick-xml's reader requires it
 
         // These are here instead of the struct because we may need to move the contents of these somewhere else
         let mut current_style_name = String::new();
         let mut current_style_value: HashMap<String, String> = HashMap::new();
 
-        let parser = EventReader::new(content_xml.unwrap());
+        let parser = EventReader::new(content_xml);
         for e in parser {
             // Iterate through the XML
             match e {

--- a/server/src/parsers/odt.rs
+++ b/server/src/parsers/odt.rs
@@ -134,7 +134,7 @@ impl ODTParser {
         let mut current_style_name: Option<String> = None;
         let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
         let local_name = &local_name[1..];
-        if prefix == "office" && local_name == "body" {
+        if name == "office:body" {
             self.body_begin = true;
         } else if self.body_begin {
             if prefix != "text" {
@@ -188,9 +188,9 @@ impl ODTParser {
                 }
                 _ => (),
             }
-        } else if prefix == "office" && local_name == "automatic-styles" {
+        } else if name == "office:automatic-styles" {
             self.styles_begin = true;
-        } else if self.styles_begin && prefix == "style" && local_name == "style" {
+        } else if self.styles_begin && name == "style:style" {
             current_style_name = Some(style_begin(attributes));
         }
         current_style_name
@@ -239,7 +239,7 @@ impl ODTParser {
         let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
         let local_name = &local_name[1..];
         if self.body_begin {
-            if prefix == "office" && local_name == "body" {
+            if name == "office:body" {
                 return Some((current_style_name, current_style_value));
             } else if prefix == "text"
                 && (local_name == "h" || local_name == "p" || local_name == "span")
@@ -273,9 +273,9 @@ impl ODTParser {
                 }
             }
         } else if self.styles_begin {
-            if prefix == "office" && local_name == "automatic-styles" {
+            if name == "office:automatic-styles" {
                 self.styles_begin = false;
-            } else if prefix == "style" && local_name == "style" {
+            } else if name == "style:style" {
                 self.auto_styles
                     .insert(current_style_name, current_style_value);
                 return None;
@@ -361,9 +361,7 @@ fn heading_begin(attributes: Attributes) -> (Element, String) {
     for i in attributes {
         if let Ok(i) = i {
             let name = std::str::from_utf8(i.key).unwrap_or(":");
-            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
-            let local_name = &local_name[1..];
-            if prefix == "text" && local_name == "outline-level" {
+            if name == "text:outline-level" {
                 level = std::str::from_utf8(
                     &i.unescaped_value()
                         .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
@@ -371,7 +369,7 @@ fn heading_begin(attributes: Attributes) -> (Element, String) {
                 .unwrap_or("1")
                 .parse::<f64>()
                 .unwrap_or(1.0);
-            } else if prefix == "text" && local_name == "style-name" {
+            } else if name == "text:style-name" {
                 style_name = std::str::from_utf8(
                     &i.unescaped_value()
                         .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
@@ -395,9 +393,7 @@ fn paragraph_begin(attributes: Attributes) -> (Element, String) {
     for i in attributes {
         if let Ok(i) = i {
             let name = std::str::from_utf8(i.key).unwrap_or(":");
-            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
-            let local_name = &local_name[1..];
-            if prefix == "text" && local_name == "style-name" {
+            if name == "text:style-name" {
                 style_name = std::str::from_utf8(
                     &i.unescaped_value()
                         .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
@@ -417,9 +413,7 @@ fn span_begin(attributes: Attributes) -> (Element, String) {
     for i in attributes {
         if let Ok(i) = i {
             let name = std::str::from_utf8(i.key).unwrap_or(":");
-            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
-            let local_name = &local_name[1..];
-            if prefix == "text" && local_name == "style-name" {
+            if name == "text:style-name" {
                 style_name = std::str::from_utf8(
                     &i.unescaped_value()
                         .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
@@ -438,9 +432,7 @@ fn style_begin(attributes: Attributes) -> String {
     for i in attributes {
         if let Ok(i) = i {
             let name = std::str::from_utf8(i.key).unwrap_or(":");
-            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
-            let local_name = &local_name[1..];
-            if prefix == "style" && local_name == "name" {
+            if name == "style:name" {
                 return std::str::from_utf8(
                     &i.unescaped_value()
                         .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),

--- a/server/src/parsers/odt.rs
+++ b/server/src/parsers/odt.rs
@@ -1,13 +1,15 @@
+extern crate quick_xml;
 extern crate serde_json;
-extern crate xml;
 extern crate zip;
 
 use crate::document::node::{Element, Node, Text};
 use crate::document::units::DistanceUnit;
 use crate::document::{Document, PaperSize};
+use quick_xml::events::attributes::Attributes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
 use std::collections::HashMap;
 use std::io::BufReader;
-use xml::reader::{EventReader, XmlEvent};
 
 pub struct ODTParser {
     body_begin: bool,
@@ -65,15 +67,17 @@ impl ODTParser {
         let mut current_style_name = String::new();
         let mut current_style_value: HashMap<String, String> = HashMap::new();
 
-        let parser = EventReader::new(content_xml);
-        for e in parser {
+        let mut parser = Reader::from_reader(content_xml);
+        let mut buffer = Vec::new();
+        loop {
             // Iterate through the XML
-            match e {
-                Ok(XmlEvent::StartElement {
-                    name, attributes, ..
-                }) => {
-                    let (current_style_name_new, current_style_value_new) =
-                        self.handle_element_start(name, attributes);
+            match parser.read_event(&mut buffer) {
+                Ok(Event::Start(contents)) => {
+                    let (current_style_name_new, current_style_value_new) = self
+                        .handle_element_start(
+                            std::str::from_utf8(contents.name()).unwrap_or(":"),
+                            contents.attributes(),
+                        );
                     if let Some(x) = current_style_name_new {
                         current_style_name = x;
                     }
@@ -81,10 +85,20 @@ impl ODTParser {
                         current_style_value = x;
                     }
                 }
-                Ok(XmlEvent::Characters(contents)) => self.handle_characters(contents),
-                Ok(XmlEvent::EndElement { name }) => {
-                    let result =
-                        self.handle_element_end(name, current_style_name, current_style_value);
+                Ok(Event::Text(contents)) => {
+                    let contents = contents.unescape_and_decode(&parser);
+                    if let Err(e) = contents {
+                        println!("Error: {}", e);
+                    } else {
+                        self.handle_characters(contents.unwrap());
+                    }
+                }
+                Ok(Event::End(contents)) => {
+                    let result = self.handle_element_end(
+                        std::str::from_utf8(contents.name()).unwrap_or(":"),
+                        current_style_name,
+                        current_style_value,
+                    );
                     if let Some(x) = result {
                         // If they were not used inside handle_element_end() then put them back
                         let (current_style_name_new, current_style_value_new) = x;
@@ -96,6 +110,7 @@ impl ODTParser {
                         current_style_value = HashMap::new();
                     }
                 }
+                Ok(Event::Eof) => break,
                 Err(e) => {
                     println!("Error: {}", e);
                     return Err(e.to_string());
@@ -112,74 +127,74 @@ impl ODTParser {
     /// as well as mutating internal state accordingly
     fn handle_element_start(
         &mut self,
-        name: xml::name::OwnedName,
-        attributes: Vec<xml::attribute::OwnedAttribute>,
+        name: &str,
+        attributes: Attributes,
     ) -> (Option<String>, Option<HashMap<String, String>>) {
         let mut current_style_name: Option<String> = None;
         let mut current_style_value: Option<HashMap<String, String>> = None;
-        if let Some(prefix) = name.prefix {
-            if prefix == "office" && name.local_name == "body" {
-                self.body_begin = true;
-            } else if self.body_begin {
-                if prefix != "text" {
-                    return (current_style_name, current_style_value);
+        let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+        let local_name = &local_name[1..];
+        if prefix == "office" && local_name == "body" {
+            self.body_begin = true;
+        } else if self.body_begin {
+            if prefix != "text" {
+                return (current_style_name, current_style_value);
+            }
+            match local_name {
+                "h" => {
+                    let (element, set_children_underline_new, ensure_children_no_underline_new) =
+                        check_underline(
+                            heading_begin(attributes),
+                            &self.auto_styles,
+                            !self.set_children_underline.is_empty()
+                                && *self.set_children_underline.last().unwrap(),
+                            !self.ensure_children_no_underline.is_empty()
+                                && *self.ensure_children_no_underline.last().unwrap(),
+                        );
+                    self.ensure_children_no_underline
+                        .push(ensure_children_no_underline_new);
+                    self.set_children_underline.push(set_children_underline_new);
+                    self.document_hierarchy.push(element);
                 }
-                match name.local_name.as_str() {
-                    "h" => {
-                        let (element, set_children_underline_new, ensure_children_no_underline_new) =
-                            check_underline(
-                                heading_begin(attributes),
-                                &self.auto_styles,
-                                !self.set_children_underline.is_empty()
-                                    && *self.set_children_underline.last().unwrap(),
-                                !self.ensure_children_no_underline.is_empty()
-                                    && *self.ensure_children_no_underline.last().unwrap(),
-                            );
-                        self.ensure_children_no_underline
-                            .push(ensure_children_no_underline_new);
-                        self.set_children_underline.push(set_children_underline_new);
-                        self.document_hierarchy.push(element);
-                    }
-                    "p" => {
-                        let (element, set_children_underline_new, ensure_children_no_underline_new) =
-                            check_underline(
-                                paragraph_begin(attributes),
-                                &self.auto_styles,
-                                !self.set_children_underline.is_empty()
-                                    && *self.set_children_underline.last().unwrap(),
-                                !self.ensure_children_no_underline.is_empty()
-                                    && *self.ensure_children_no_underline.last().unwrap(),
-                            );
-                        self.ensure_children_no_underline
-                            .push(ensure_children_no_underline_new);
-                        self.set_children_underline.push(set_children_underline_new);
-                        self.document_hierarchy.push(element);
-                    }
-                    "span" => {
-                        let (element, set_children_underline_new, ensure_children_no_underline_new) =
-                            check_underline(
-                                span_begin(attributes),
-                                &self.auto_styles,
-                                !self.set_children_underline.is_empty()
-                                    && *self.set_children_underline.last().unwrap(),
-                                !self.ensure_children_no_underline.is_empty()
-                                    && *self.ensure_children_no_underline.last().unwrap(),
-                            );
-                        self.ensure_children_no_underline
-                            .push(ensure_children_no_underline_new);
-                        self.set_children_underline.push(set_children_underline_new);
-                        self.document_hierarchy.push(element);
-                    }
-                    _ => (),
+                "p" => {
+                    let (element, set_children_underline_new, ensure_children_no_underline_new) =
+                        check_underline(
+                            paragraph_begin(attributes),
+                            &self.auto_styles,
+                            !self.set_children_underline.is_empty()
+                                && *self.set_children_underline.last().unwrap(),
+                            !self.ensure_children_no_underline.is_empty()
+                                && *self.ensure_children_no_underline.last().unwrap(),
+                        );
+                    self.ensure_children_no_underline
+                        .push(ensure_children_no_underline_new);
+                    self.set_children_underline.push(set_children_underline_new);
+                    self.document_hierarchy.push(element);
                 }
-            } else if prefix == "office" && name.local_name == "automatic-styles" {
-                self.styles_begin = true;
-            } else if self.styles_begin {
-                if prefix == "style" && name.local_name == "style" {
-                    current_style_name = Some(style_begin(attributes));
-                } else if prefix == "style" && name.local_name == "text-properties" {
-                    current_style_value = Some(text_properties_begin(attributes));
+                "span" => {
+                    let (element, set_children_underline_new, ensure_children_no_underline_new) =
+                        check_underline(
+                            span_begin(attributes),
+                            &self.auto_styles,
+                            !self.set_children_underline.is_empty()
+                                && *self.set_children_underline.last().unwrap(),
+                            !self.ensure_children_no_underline.is_empty()
+                                && *self.ensure_children_no_underline.last().unwrap(),
+                        );
+                    self.ensure_children_no_underline
+                        .push(ensure_children_no_underline_new);
+                    self.set_children_underline.push(set_children_underline_new);
+                    self.document_hierarchy.push(element);
                 }
+                _ => (),
+            }
+        } else if prefix == "office" && local_name == "automatic-styles" {
+            self.styles_begin = true;
+        } else if self.styles_begin {
+            if prefix == "style" && local_name == "style" {
+                current_style_name = Some(style_begin(attributes));
+            } else if prefix == "style" && local_name == "text-properties" {
+                current_style_value = Some(text_properties_begin(attributes));
             }
         }
         (current_style_name, current_style_value)
@@ -206,57 +221,53 @@ impl ODTParser {
     /// then it will return the current_style_name and current_style_value back if they were not used
     fn handle_element_end(
         &mut self,
-        name: xml::name::OwnedName,
+        name: &str,
         current_style_name: String,
         current_style_value: HashMap<String, String>,
     ) -> Option<(String, HashMap<String, String>)> {
+        let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+        let local_name = &local_name[1..];
         if self.body_begin {
-            if let Some(prefix) = name.prefix {
-                if prefix == "office" && name.local_name == "body" {
+            if prefix == "office" && local_name == "body" {
+                return Some((current_style_name, current_style_value));
+            } else if prefix == "text"
+                && (local_name == "h" || local_name == "p" || local_name == "span")
+            {
+                if self.document_hierarchy.is_empty() {
+                    // It shouldn't be empty now, if it is then this is an unmatched end tag
                     return Some((current_style_name, current_style_value));
-                } else if prefix == "text"
-                    && (name.local_name == "h"
-                        || name.local_name == "p"
-                        || name.local_name == "span")
-                {
-                    if self.document_hierarchy.is_empty() {
-                        // It shouldn't be empty now, if it is then this is an unmatched end tag
-                        return Some((current_style_name, current_style_value));
-                    }
-                    // The top of set_children_underline and ensure_children_no_underline is for this node's children,
-                    // so pop them here before we finish up with this node
-                    self.set_children_underline.pop();
-                    self.ensure_children_no_underline.pop();
-                    let mut child = self.document_hierarchy.pop().unwrap();
-                    if name.local_name == "span" {
-                        handle_underline(
-                            &mut child.styles,
-                            !self.set_children_underline.is_empty()
-                                && *self.set_children_underline.last().unwrap(),
-                            !self.ensure_children_no_underline.is_empty()
-                                && *self.ensure_children_no_underline.last().unwrap(),
-                        );
-                    }
-                    if self.document_hierarchy.is_empty() {
-                        self.document_root.children.push(Node::Element(child));
-                    } else {
-                        self.document_hierarchy
-                            .last_mut()
-                            .unwrap()
-                            .children
-                            .push(Node::Element(child));
-                    }
+                }
+                // The top of set_children_underline and ensure_children_no_underline is for this node's children,
+                // so pop them here before we finish up with this node
+                self.set_children_underline.pop();
+                self.ensure_children_no_underline.pop();
+                let mut child = self.document_hierarchy.pop().unwrap();
+                if local_name == "span" {
+                    handle_underline(
+                        &mut child.styles,
+                        !self.set_children_underline.is_empty()
+                            && *self.set_children_underline.last().unwrap(),
+                        !self.ensure_children_no_underline.is_empty()
+                            && *self.ensure_children_no_underline.last().unwrap(),
+                    );
+                }
+                if self.document_hierarchy.is_empty() {
+                    self.document_root.children.push(Node::Element(child));
+                } else {
+                    self.document_hierarchy
+                        .last_mut()
+                        .unwrap()
+                        .children
+                        .push(Node::Element(child));
                 }
             }
         } else if self.styles_begin {
-            if let Some(prefix) = name.prefix {
-                if prefix == "office" && name.local_name == "automatic-styles" {
-                    self.styles_begin = false;
-                } else if prefix == "style" && name.local_name == "style" {
-                    self.auto_styles
-                        .insert(current_style_name, current_style_value);
-                    return None;
-                }
+            if prefix == "office" && local_name == "automatic-styles" {
+                self.styles_begin = false;
+            } else if prefix == "style" && local_name == "style" {
+                self.auto_styles
+                    .insert(current_style_name, current_style_value);
+                return None;
             }
         }
         Some((current_style_name, current_style_value))
@@ -332,16 +343,31 @@ fn handle_underline(
 /// Takes the set of attributes of a text:h tag in the ODT's content.xml,
 /// and returns a heading element based on the attributes,
 /// together with the value of the text:style-name attribute of the tag
-fn heading_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element, String) {
+fn heading_begin(attributes: Attributes) -> (Element, String) {
     // Because JS numbers are always floats apparently
     let mut level = 0.0;
     let mut style_name = String::new();
     for i in attributes {
-        let prefix = i.name.prefix.unwrap_or_else(|| "".to_string());
-        if prefix == "text" && i.name.local_name == "outline-level" {
-            level = i.value.parse::<f64>().unwrap_or(1.0);
-        } else if prefix == "text" && i.name.local_name == "style-name" {
-            style_name = i.value;
+        if let Ok(i) = i {
+            let name = std::str::from_utf8(i.key).unwrap_or(":");
+            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+            let local_name = &local_name[1..];
+            if prefix == "text" && local_name == "outline-level" {
+                level = std::str::from_utf8(
+                    &i.unescaped_value()
+                        .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+                )
+                .unwrap_or("1")
+                .parse::<f64>()
+                .unwrap_or(1.0);
+            } else if prefix == "text" && local_name == "style-name" {
+                style_name = std::str::from_utf8(
+                    &i.unescaped_value()
+                        .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+                )
+                .unwrap_or("")
+                .to_string();
+            }
         }
     }
     let mut element = Element::new("heading".to_string());
@@ -353,13 +379,21 @@ fn heading_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element, S
 
 /// Takes the set of attributes of a text:p tag in the ODT's content.xml,
 /// and returns a paragraph element together with the value of the text:style-name attribute of the tag
-fn paragraph_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element, String) {
+fn paragraph_begin(attributes: Attributes) -> (Element, String) {
     let mut style_name = String::new();
     for i in attributes {
-        if i.name.prefix.unwrap_or_else(|| "".to_string()) == "text"
-            && i.name.local_name == "style-name"
-        {
-            style_name = i.value;
+        if let Ok(i) = i {
+            let name = std::str::from_utf8(i.key).unwrap_or(":");
+            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+            let local_name = &local_name[1..];
+            if prefix == "text" && local_name == "style-name" {
+                style_name = std::str::from_utf8(
+                    &i.unescaped_value()
+                        .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+                )
+                .unwrap_or("")
+                .to_string();
+            }
         }
     }
     (Element::new("paragraph".to_string()), style_name)
@@ -367,13 +401,21 @@ fn paragraph_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element,
 
 /// Takes the set of attributes of a text:span tag in the ODT's content.xml
 /// and returns a span element together with the value of the text:style-name attribute of the tag
-fn span_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element, String) {
+fn span_begin(attributes: Attributes) -> (Element, String) {
     let mut style_name = String::new();
     for i in attributes {
-        if i.name.prefix.unwrap_or_else(|| "".to_string()) == "text"
-            && i.name.local_name == "style-name"
-        {
-            style_name = i.value;
+        if let Ok(i) = i {
+            let name = std::str::from_utf8(i.key).unwrap_or(":");
+            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+            let local_name = &local_name[1..];
+            if prefix == "text" && local_name == "style-name" {
+                style_name = std::str::from_utf8(
+                    &i.unescaped_value()
+                        .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+                )
+                .unwrap_or("")
+                .to_string();
+            }
         }
     }
     (Element::new("span".to_string()), style_name)
@@ -381,11 +423,20 @@ fn span_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> (Element, Stri
 
 /// Takes the set of attributes of a style:style tag in the ODT's content.xml,
 /// and returns the name of the style
-fn style_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> String {
+fn style_begin(attributes: Attributes) -> String {
     for i in attributes {
-        if i.name.prefix.unwrap_or_else(|| "".to_string()) == "style" && i.name.local_name == "name"
-        {
-            return i.value;
+        if let Ok(i) = i {
+            let name = std::str::from_utf8(i.key).unwrap_or(":");
+            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+            let local_name = &local_name[1..];
+            if prefix == "style" && local_name == "name" {
+                return std::str::from_utf8(
+                    &i.unescaped_value()
+                        .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+                )
+                .unwrap_or("")
+                .to_string();
+            }
         }
     }
     String::new()
@@ -393,60 +444,70 @@ fn style_begin(attributes: Vec<xml::attribute::OwnedAttribute>) -> String {
 
 /// Takes the set of attributes of a style:text-properties tag in the ODT's content.xml,
 /// and creates a map of CSS properties based on the attributes
-fn text_properties_begin(
-    attributes: Vec<xml::attribute::OwnedAttribute>,
-) -> HashMap<String, String> {
+fn text_properties_begin(attributes: Attributes) -> HashMap<String, String> {
     let mut map: HashMap<String, String> = HashMap::new();
     let mut is_double_underline = false;
     for i in attributes {
-        let prefix = i.name.prefix.unwrap_or_else(|| "".to_string());
-        if prefix == "fo" {
-            if i.name.local_name == "font-weight" {
-                // All valid values for this attribute is also valid in the CSS equivalent, so just use it as is
-                map.insert("fontWeight".to_string(), i.value);
-            } else if i.name.local_name == "font-style" && i.value != "backslant" {
-                // `backslant` is not valid in CSS, but all the other ones are
-                map.insert("fontStyle".to_string(), i.value);
-            } else if i.name.local_name == "color" {
-                map.insert("color".to_string(), i.value);
-            } else if i.name.local_name == "font-size" {
-                map.insert("fontSize".to_string(), i.value);
-            }
-        } else if prefix == "style" {
-            if i.name.local_name == "text-underline-style" {
-                if i.value == "none" {
-                    map.insert("textDecorationLine".to_string(), "none".to_string());
-                } else {
-                    map.insert("textDecorationLine".to_string(), "underline".to_string());
-                    match i.value.as_ref() {
-                        "dash" => {
-                            map.insert("textDecorationStyle".to_string(), "dashed".to_string())
-                        }
-                        "dotted" => {
-                            map.insert("textDecorationStyle".to_string(), "dotted".to_string())
-                        }
-                        "wave" => map.insert("textDecorationStyle".to_string(), "wavy".to_string()),
-                        // There are a few possible styles in ODF that aren't present in CSS
-                        // (dot-dash, dot-dot-dash, long-dash), so just put in a basic underline?
-                        "solid" | _ => {
-                            map.insert("textDecorationStyle".to_string(), "solid".to_string())
-                        }
-                    };
+        if let Ok(i) = i {
+            let name = std::str::from_utf8(i.key).unwrap_or(":");
+            let (prefix, local_name) = name.split_at(name.find(':').unwrap_or(0));
+            let local_name = &local_name[1..];
+            let value = std::str::from_utf8(
+                &i.unescaped_value()
+                    .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
+            )
+            .unwrap_or("")
+            .to_string();
+            if prefix == "fo" {
+                if local_name == "font-weight" {
+                    // All valid values for this attribute is also valid in the CSS equivalent, so just use it as is
+                    map.insert("fontWeight".to_string(), value);
+                } else if local_name == "font-style" && value != "backslant" {
+                    // `backslant` is not valid in CSS, but all the other ones are
+                    map.insert("fontStyle".to_string(), value);
+                } else if local_name == "color" {
+                    map.insert("color".to_string(), value);
+                } else if local_name == "font-size" {
+                    map.insert("fontSize".to_string(), value);
                 }
-            } else if i.name.local_name == "text-underline-type" && i.value == "double" {
-                is_double_underline = true;
-            } else if i.name.local_name == "text-underline-color" {
-                if i.value == "font-color" {
-                    map.insert(
-                        "textDecorationColor".to_string(),
-                        "currentcolor".to_string(),
-                    );
-                } else {
-                    // The other valid values are all in hex format
-                    map.insert("textDecorationColor".to_string(), i.value);
+            } else if prefix == "style" {
+                if local_name == "text-underline-style" {
+                    if value == "none" {
+                        map.insert("textDecorationLine".to_string(), "none".to_string());
+                    } else {
+                        map.insert("textDecorationLine".to_string(), "underline".to_string());
+                        match value.as_str() {
+                            "dash" => {
+                                map.insert("textDecorationStyle".to_string(), "dashed".to_string())
+                            }
+                            "dotted" => {
+                                map.insert("textDecorationStyle".to_string(), "dotted".to_string())
+                            }
+                            "wave" => {
+                                map.insert("textDecorationStyle".to_string(), "wavy".to_string())
+                            }
+                            // There are a few possible styles in ODF that aren't present in CSS
+                            // (dot-dash, dot-dot-dash, long-dash), so just put in a basic underline?
+                            "solid" | _ => {
+                                map.insert("textDecorationStyle".to_string(), "solid".to_string())
+                            }
+                        };
+                    }
+                } else if local_name == "text-underline-type" && value == "double" {
+                    is_double_underline = true;
+                } else if local_name == "text-underline-color" {
+                    if value == "font-color" {
+                        map.insert(
+                            "textDecorationColor".to_string(),
+                            "currentcolor".to_string(),
+                        );
+                    } else {
+                        // The other valid values are all in hex format
+                        map.insert("textDecorationColor".to_string(), value);
+                    }
+                } else if local_name == "font-name" {
+                    map.insert("fontFamily".to_string(), value);
                 }
-            } else if i.name.local_name == "font-name" {
-                map.insert("fontFamily".to_string(), i.value);
             }
         }
     }


### PR DESCRIPTION
This actually speeds up parsing larger documents, with a 1MB ODT file 
[mega.odt.zip](https://github.com/sean0x42/kauri/files/3312985/mega.odt.zip) (GitHub doesn't support ODT files, just change the name) with 1103 pages and 600795 words it cut the parsing time from around 1000 ms to 750-800 ms. However, it is lower level now, for example it uses byte vectors instead of strings. Also, while quick-xml's API is inspired by xml-rs there are other differences, for example it doesn't automatically split the prefix and local name like what xml-rs does, so for now I just do it myself to minimise the changes required.

## Proposed Changes
 - Replace the xml-rs dependency for the ODT parser with quick-xml
 - Rework the parser to use it

## Related Stories
 - None? (impromptu)

## Acknowledgements
 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/master/.github/CONTRIBUTING.md).
 - [x] I have followed the branching requirements.
 - [x] I have run `rustfmt` and `yarn clean` on all proposed Rust and JavaScript.

Please review @sean0x42
