### PR TITLE
Hyperlink support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ not include technical details.
 
  - Added basic clipboard functionality [(#20)](https://github.com/sean0x42/kauri/pull/20)
  - Added support for tables in ODT files [(#52)](https://github.com/sean0x42/kauri/pull/52)
+ - Added support for hyperlinks [(#73)](https://github.com/sean0x42/kauri/pull/73)

--- a/client/src/renderer/components/Editor/Anchor.jsx
+++ b/client/src/renderer/components/Editor/Anchor.jsx
@@ -1,0 +1,19 @@
+/** @format */
+
+import { h } from "preact";
+import { renderDocumentNodes } from "dom/render";
+
+/**
+ * Constructs an anchor within the editor from a DOM node.
+ * @param {Object} props Component properties.
+ * @param {Object} props.node DOM Node used to create an anchor.
+ * @return {PreactElement} A rendered preact element.
+ */
+export default function Anchor(props) {
+  const { children = [], styles = {}, attributes = {} } = props.node;
+  return (
+    <a class="editor__anchor" style={styles} {...attributes}>
+      {renderDocumentNodes(children)}
+    </a>
+  );
+}

--- a/client/src/renderer/dom/render.jsx
+++ b/client/src/renderer/dom/render.jsx
@@ -11,6 +11,7 @@ import TableColumnGroup from "components/Editor/TableColumnGroup";
 import TableColumn from "components/Editor/TableColumn";
 import TableRow from "components/Editor/TableRow";
 import TableCell from "components/Editor/TableCell";
+import Anchor from "components/Editor/Anchor";
 import RenderError from "dom/RenderError";
 
 /**
@@ -78,6 +79,8 @@ function renderTag(node) {
       return <TableRow node={node} />;
     case "td":
       return <TableCell node={node} />;
+    case "a":
+      return <Anchor node={node} />;
     default:
       throw new RenderError(node, `Unknown tag '${node.tag}'.`);
   }

--- a/server/src/parsers/odt/mod.rs
+++ b/server/src/parsers/odt/mod.rs
@@ -242,7 +242,10 @@ impl ODTParser {
             if name == "office:body" {
                 return Some((current_style_name, current_style_value));
             } else if prefix == "text"
-                && (local_name == "h" || local_name == "p" || local_name == "span")
+                && (local_name == "h"
+                    || local_name == "p"
+                    || local_name == "span"
+                    || local_name == "a")
             {
                 // The top of set_children_underline and ensure_children_no_underline is for this node's children,
                 // so pop them here before we finish up with this node


### PR DESCRIPTION
### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Hyperlink support

### Current issues

 - Need named styles to support visited style
 - Can't click on the link in the editor due to contenteditable
 - How links that point to parts of the document work is not defined by the ODT spec, so LibreOffice seems to do its own thing, not accounting for them yet

❤️ Thank you for your contribution!
