### PR TITLE
Remove redundant initial state in commands.js

### DIFF
--- a/client/src/renderer/redux/reducers/commands.js
+++ b/client/src/renderer/redux/reducers/commands.js
@@ -2,11 +2,6 @@
 import { combineReducers } from "redux";
 import { ADD_COMMAND } from "../actionTypes";
 
-const initialState = {
-  allIds: [],
-  byId: {},
-};
-
 export default combineReducers({
   allIds: allCommands,
   byId: commandsById,


### PR DESCRIPTION
### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Remove redundant initial state from `commands.js`. For a bit of context, I removed a redundant reducer from this file earlier, and forgot to remove the initial state it was using.

❤️ Thank you for your contribution!
