### PR TITLE
Default outline level parsing support

### DIFF
--- a/server/src/document/node.rs
+++ b/server/src/document/node.rs
@@ -88,7 +88,9 @@ pub struct ElementCommon {
     class: Option<String>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub styles: HashMap<String, String>,
-    pub children: Vec<ChildNode>,
+    // Children is optional here because this may be used as a template in a style class, which would not have it
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<ChildNode>>,
     #[serde(skip)]
     // This is meant to store attributes that can only be processed after all of this Element's children has been accounted for,
     // so this should not be part of the JSON
@@ -103,7 +105,17 @@ impl ElementCommon {
         ElementCommon {
             class,
             styles: HashMap::new(),
-            children: Vec::new(),
+            children: Some(Vec::new()),
+            attributes: HashMap::new(),
+        }
+    }
+
+    /// Constructs a new ElementCommon struct meant to be used as a template for a style class
+    pub fn new_template() -> ElementCommon {
+        ElementCommon {
+            class: None,
+            styles: HashMap::new(),
+            children: None,
             attributes: HashMap::new(),
         }
     }

--- a/server/src/document/node.rs
+++ b/server/src/document/node.rs
@@ -140,6 +140,16 @@ impl Heading {
             level,
         }
     }
+
+    /// Constructs a new Heading element for use as a template for a style class
+    ///
+    /// - `level` Level of the heading
+    pub fn new_template(level: u32) -> Heading {
+        Heading {
+            common: ElementCommon::new_template(),
+            level,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/server/src/document/styles.rs
+++ b/server/src/document/styles.rs
@@ -1,3 +1,4 @@
+use super::node::Element;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -24,6 +25,8 @@ pub struct Style {
     display: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     inherit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    element: Option<Element>,
     pub styles: HashMap<String, String>,
 }
 
@@ -32,10 +35,12 @@ impl Style {
     ///
     /// - `display` A human-readable string which can be shown to users.
     /// - `inherit` A string containing the unique ID of another class, from which to inherit styles from.
-    pub fn new(display: String, inherit: Option<String>) -> Style {
+    /// - `element` An optional Element that will be used as a template
+    pub fn new(display: String, inherit: Option<String>, element: Option<Element>) -> Style {
         Style {
             display,
             inherit,
+            element,
             styles: HashMap::new(),
         }
     }

--- a/server/src/parsers/odt/mod.rs
+++ b/server/src/parsers/odt/mod.rs
@@ -226,6 +226,8 @@ impl ODTParser {
             .unwrap()
             .get_common()
             .children
+            .as_mut()
+            .unwrap()
             .push(ChildNode::Node(Node::Text(text)));
     }
 
@@ -275,6 +277,8 @@ impl ODTParser {
                         .unwrap()
                         .get_common()
                         .children
+                        .as_mut()
+                        .unwrap()
                         .push(ChildNode::Element(child));
                 }
             } else if prefix == "table" {

--- a/server/src/parsers/odt/table.rs
+++ b/server/src/parsers/odt/table.rs
@@ -86,6 +86,8 @@ impl ODTParser {
                         .unwrap()
                         .get_common()
                         .children
+                        .as_mut()
+                        .unwrap()
                         .push(ChildNode::Element(child));
                 }
                 self.table_column_default_style_names.pop();
@@ -115,6 +117,8 @@ impl ODTParser {
                             .unwrap()
                             .get_common()
                             .children
+                            .as_mut()
+                            .unwrap()
                             .push(ChildNode::Element(child.clone()));
                     }
                     repeat -= 1;
@@ -142,6 +146,8 @@ impl ODTParser {
                             .unwrap()
                             .get_common()
                             .children
+                            .as_mut()
+                            .unwrap()
                             .push(ChildNode::Element(child.clone()));
                     }
                     repeat -= 1;
@@ -164,13 +170,17 @@ impl ODTParser {
             .last_mut()
             .unwrap()
             .get_common()
-            .children[1]
+            .children
+            .as_mut()
+            .unwrap()[1]
         {
             let (table, default_cell_style_name, mut repeat) =
                 table_column_begin(attributes, &self.auto_styles);
             element
                 .get_common()
                 .children
+                .as_mut()
+                .unwrap()
                 .push(ChildNode::Element(table));
             let table_column_default_style_names =
                 self.table_column_default_style_names.last_mut().unwrap();
@@ -570,11 +580,15 @@ fn table_begin(
     // so we add it in in order to have a definitive position as to where the colgroup will come
     element
         .children
+        .as_mut()
+        .unwrap()
         .push(ChildNode::Element(Element::Caption(ElementCommon::new(
             None,
         ))));
     element
         .children
+        .as_mut()
+        .unwrap()
         .push(ChildNode::Element(Element::TableColumnGroup(
             ElementCommon::new(None),
         )));

--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -128,6 +128,8 @@ impl ODTParser {
                     .unwrap()
                     .get_common()
                     .children
+                    .as_mut()
+                    .unwrap()
                     .push(ChildNode::Element(element));
             }
         }


### PR DESCRIPTION
Default outline level is what ODT calls the attribute that indicates what level of a heading that the target element should be set to when the style class is applied to it.

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Added support for style class templates in the server
 - Added support for parsing default outline level

❤️ Thank you for your contribution!
