### PR TITLE
Bump Preact to 10.0.0-rc.1 (new release candidate)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "babel-jest": "^24.8.0",
     "electron-clipboard-extended": "^1.1.1",
-    "preact": "10.0.0-rc.0",
+    "preact": "^10.0.0-rc.1",
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6899,10 +6899,10 @@ posthtml@^0.11.2, posthtml@^0.11.3:
     posthtml-parser "^0.4.1"
     posthtml-render "^1.1.5"
 
-preact@10.0.0-rc.0:
-  version "10.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-rc.0.tgz#084316631ae6f0a965e889e7715cccb74c4a5d6e"
-  integrity sha512-mOOF2FoSt52uYPa+n2cvgI0NI+yo6Rxyamvu5z/8GHod3UhtExWhBcOeTawriR4HiGuR5VHENJEJ/dtBWMZZaQ==
+preact@^10.0.0-rc.1:
+  version "10.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-rc.1.tgz#bae4419f8e289c327504d4ee6e734c377983548c"
+  integrity sha512-DyG8ySCbrQZ8w4cSyxnofM6yH/hzyYLHmIrE3xL1FjSCX4DpvVmP7DTpkV535FSQX0d2zOscb7DCIY+crBtxow==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Bump Preact to 10.0.0-rc.1. See [Preact release notes](https://github.com/preactjs/preact/releases/tag/10.0.0-rc.1) for more info.

❤️ Thank you for your contribution!
