### PR TITLE
ODT List Parsing

### DIFF
--- a/server/src/document/node.rs
+++ b/server/src/document/node.rs
@@ -181,6 +181,18 @@ impl List {
             bullet,
         }
     }
+
+    /// Constructs a new List element for use as a template in a style class
+    ///
+    /// - `bullet_cycle` Cycle of the bullets.
+    /// - `bullet` Type of the list bullet.
+    pub fn new_template(bullet_cycle: Option<Vec<ListBullet>>, bullet: Option<ListBullet>) -> List {
+        List {
+            common: ElementCommon::new_template(),
+            bullet_cycle,
+            bullet,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/server/src/document/styles.rs
+++ b/server/src/document/styles.rs
@@ -26,7 +26,7 @@ pub struct Style {
     #[serde(skip_serializing_if = "Option::is_none")]
     inherit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    element: Option<Element>,
+    pub element: Option<Element>,
     pub styles: HashMap<String, String>,
 }
 
@@ -36,11 +36,11 @@ impl Style {
     /// - `display` A human-readable string which can be shown to users.
     /// - `inherit` A string containing the unique ID of another class, from which to inherit styles from.
     /// - `element` An optional Element that will be used as a template
-    pub fn new(display: String, inherit: Option<String>, element: Option<Element>) -> Style {
+    pub fn new(display: String, inherit: Option<String>) -> Style {
         Style {
             display,
             inherit,
-            element,
+            element: None,
             styles: HashMap::new(),
         }
     }

--- a/server/src/parsers/odt/mod.rs
+++ b/server/src/parsers/odt/mod.rs
@@ -359,6 +359,20 @@ impl ODTParser {
                 }
             } else if prefix == "table" {
                 self.handle_element_end_table(local_name);
+            } else if name == "text:list" || name == "text:list-item" {
+                let child = self.document_hierarchy.pop().unwrap();
+                if self.document_hierarchy.is_empty() {
+                    self.document_root.content.push(ChildNode::Element(child));
+                } else {
+                    self.document_hierarchy
+                        .last_mut()
+                        .unwrap()
+                        .get_common()
+                        .children
+                        .as_mut()
+                        .unwrap()
+                        .push(ChildNode::Element(child));
+                }
             }
         } else if self.styles_begin {
             if name == "office:automatic-styles" {

--- a/server/src/parsers/odt/styles.rs
+++ b/server/src/parsers/odt/styles.rs
@@ -243,10 +243,9 @@ fn style_style_begin(attributes: Attributes) -> (String, Style) {
         let heading = Heading::new_template(default_outline_level);
         element = Some(Element::Heading(heading));
     }
-    (
-        style_name,
-        Style::new(display_name, Some(parent_style_name), element),
-    )
+    let mut style = Style::new(display_name, Some(parent_style_name));
+    style.element = element;
+    (style_name, style)
 }
 
 /// Helper for handle_element_empty() to respond to tags with "style" prefix
@@ -346,7 +345,7 @@ fn default_style_begin(attributes: Attributes) -> (String, Style) {
         }
     }
     // use an empty string as the displayed string for default styles for now
-    (style_name, Style::new("".to_string(), None, None))
+    (style_name, Style::new("".to_string(), None))
 }
 
 /// Helper for handle_element_start() to handle style tags which aren't prefixed by "style"


### PR DESCRIPTION
There are a few missing features still, which are:
 - Continuing previous lists (either right before or anywhere before, may require keeping track of list IDs)
 - List headers (list item without the bullet)
 - Start value for list item (as an override)
 - Style override for list item (specifies a different bullet cycle, etc for a specific list item)
 - Parsing numbered paragraphs (an alternate representation of lists in ODT, though LibreOffice doesn't seem to use it at least)

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Support for parsing lists in ODT (with caveats above)

❤️ Thank you for your contribution!
