### PR TITLE
ODT line and page break parsing support

### DIFF
--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::document::node::{ElementCommon, Heading, Hyperlink};
+use crate::document::node::{ElementCommon, Heading, Hyperlink, Node};
 
 impl ODTParser {
     /// Helper for handle_element_start() to respond to tags with "text" prefix
@@ -116,6 +116,38 @@ impl ODTParser {
                         && *self.ensure_children_no_underline.last().unwrap(),
                 );
                 child = Some(element);
+            }
+            "soft-page-break" => {
+                if self.document_hierarchy.is_empty() {
+                    self.document_root
+                        .content
+                        .push(ChildNode::Node(Node::PageBreak));
+                } else {
+                    self.document_hierarchy
+                        .last_mut()
+                        .unwrap()
+                        .get_common()
+                        .children
+                        .as_mut()
+                        .unwrap()
+                        .push(ChildNode::Node(Node::PageBreak));
+                }
+            }
+            "line-break" => {
+                if self.document_hierarchy.is_empty() {
+                    self.document_root
+                        .content
+                        .push(ChildNode::Node(Node::LineBreak));
+                } else {
+                    self.document_hierarchy
+                        .last_mut()
+                        .unwrap()
+                        .get_common()
+                        .children
+                        .as_mut()
+                        .unwrap()
+                        .push(ChildNode::Node(Node::LineBreak));
+                }
             }
             _ => (),
         }


### PR DESCRIPTION
Note that LibreOffice actually uses the break-before attribute to create page breaks, which is not handled here (it will be when support for paragraph properties is added).

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Add support for parsing line and page break tags in ODT

❤️ Thank you for your contribution!
