### PR TITLE
Fixed fetching from server

### DIFF
--- a/client/src/renderer/components/Application/index.jsx
+++ b/client/src/renderer/components/Application/index.jsx
@@ -12,7 +12,6 @@ import Editor from "components/Editor";
  */
 export default class Application extends Component {
   componentDidMount() {
-    console.log("Mounted")
     configureMenu();
   }
 
@@ -22,4 +21,3 @@ export default class Application extends Component {
     </div>
   );
 }
-

--- a/client/src/renderer/helpers/menu.js
+++ b/client/src/renderer/helpers/menu.js
@@ -11,17 +11,18 @@ const menuTemplate = [
       {
         label: "Open",
         click: () => {
-          const path = remote.dialog.showOpenDialog({ properties: ["openFile"] });
+          const path = remote.dialog.showOpenDialog({
+            properties: ["openFile"],
+          });
           store.dispatch(fetchDoc(path));
         },
       },
       process.platform === "darwin" ? { role: "close" } : { role: "quit" },
     ],
-  }
-]
+  },
+];
 
 export function configureMenu() {
-  console.log("Building menu")
   const menu = remote.Menu.buildFromTemplate(menuTemplate);
   remote.Menu.setApplicationMenu(menu);
 }

--- a/client/src/renderer/redux/actions/document.js
+++ b/client/src/renderer/redux/actions/document.js
@@ -7,12 +7,12 @@ import {
 } from "./types";
 
 export const fetchDocRequest = () => ({
-  type: FETCH_DOC_REQUEST
+  type: FETCH_DOC_REQUEST,
 });
 
 export const fetchDocError = exception => ({
   type: FETCH_DOC_ERROR,
-  exception
+  exception,
 });
 
 export const fetchDocSuccess = payload => ({

--- a/client/src/renderer/redux/actions/document.js
+++ b/client/src/renderer/redux/actions/document.js
@@ -27,7 +27,6 @@ export function fetchDoc(path) {
 
     fetch("http://localhost:3000/load", {
       method: "POST",
-      mode: "no-cors",
       body: path,
     })
       .then(response => response.json())

--- a/server/src/controllers/load.rs
+++ b/server/src/controllers/load.rs
@@ -1,10 +1,10 @@
-use std::io::Cursor;
 use super::util::create_response;
 use crate::parsers::odt::ODTParser;
+use std::io::Cursor;
 use tiny_http::{Request, Response};
 
 /// Handles a request for loading a file
-pub fn load_controller(mut request: Request) -> Response<Cursor<Vec<u8>>> {
+pub fn load_controller(request: &mut Request) -> Response<Cursor<Vec<u8>>> {
     let req_reader = request.as_reader();
     let mut body_bytes: Vec<u8> = Vec::new();
     if let Err(e) = req_reader.read_to_end(&mut body_bytes) {
@@ -26,15 +26,12 @@ pub fn load_controller(mut request: Request) -> Response<Cursor<Vec<u8>>> {
     match extension {
         // Pick a parser depending on the file extension
         Some("odt") => handle_odt(request, filepath),
-        _ => create_response(
-            "File extension missing or unrecognized".to_string(),
-            true,
-        ),
+        _ => create_response("File extension missing or unrecognized".to_string(), true),
     }
 }
 
 /// Handles a request for loading an ODT
-fn handle_odt(request: Request, filepath: &str) -> Response<Cursor<Vec<u8>>> {
+fn handle_odt(request: &Request, filepath: &str) -> Response<Cursor<Vec<u8>>> {
     let mut parser = ODTParser::new();
     let parsed_odt = parser.parse(filepath);
     if let Err(e) = parsed_odt {

--- a/server/src/controllers/load.rs
+++ b/server/src/controllers/load.rs
@@ -25,13 +25,13 @@ pub fn load_controller(request: &mut Request) -> Response<Cursor<Vec<u8>>> {
     let extension = filepath.split('.').last();
     match extension {
         // Pick a parser depending on the file extension
-        Some("odt") => handle_odt(request, filepath),
+        Some("odt") => handle_odt(filepath),
         _ => create_response("File extension missing or unrecognized".to_string(), true),
     }
 }
 
 /// Handles a request for loading an ODT
-fn handle_odt(request: &Request, filepath: &str) -> Response<Cursor<Vec<u8>>> {
+fn handle_odt(filepath: &str) -> Response<Cursor<Vec<u8>>> {
     let mut parser = ODTParser::new();
     let parsed_odt = parser.parse(filepath);
     if let Err(e) = parsed_odt {

--- a/server/src/controllers/util.rs
+++ b/server/src/controllers/util.rs
@@ -1,5 +1,5 @@
-use tiny_http::Response;
 use std::io::Cursor;
+use tiny_http::Response;
 
 pub fn create_response(msg: String, is_error: bool) -> Response<Cursor<Vec<u8>>> {
     let mut response = Response::from_string(msg);


### PR DESCRIPTION
Apparently it's possible to get it to scroll within a page (notice the heading at the top). 
Also, are page breaks still meant to render like `----- Page Break -----` at the moment?

![Screenshot_20190920_212608](https://user-images.githubusercontent.com/18729369/65323790-ab595000-dbed-11e9-9128-6270872d5bf7.png)

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Got the fetch request from the client to work even when running via `yarn start`

❤️ Thank you for your contribution!
