### PR TITLE
Parse the rest of the text-properties tag in ODT where possible

### DIFF
--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -525,6 +525,18 @@ fn text_properties_begin_fo(local_name: &str, value: String, styles: &mut HashMa
             // `backslant` is not valid in CSS, but all the other ones are
             styles.insert("fontStyle".to_string(), value);
         }
+        "font-family" => {
+            if let Some(font_name) = styles.remove("fontFamily") {
+                // If the font name is there already then prepend the font family to it
+                styles.insert(
+                    "fontFamily".to_string(),
+                    format!("{}, {}", value, font_name),
+                );
+            } else {
+                // Otherwise just put the font family there
+                styles.insert("fontFamily".to_string(), value);
+            }
+        }
         "color" => {
             styles.insert("color".to_string(), value);
         }
@@ -565,7 +577,16 @@ fn text_properties_begin_style(
     match local_name {
         "text-underline-type" if value == "double" => true,
         "font-name" => {
-            styles.insert("fontFamily".to_string(), value);
+            if let Some(font_family) = styles.remove("fontFamily") {
+                // If the font family was already set previously then append the font name
+                styles.insert(
+                    "fontFamily".to_string(),
+                    format!("{}, {}", font_family, value),
+                );
+            } else {
+                // Otherwise just put the font name there
+                styles.insert("fontFamily".to_string(), value);
+            }
             false
         }
         "text-underline-style" => {

--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -531,6 +531,24 @@ fn text_properties_begin_fo(local_name: &str, value: String, styles: &mut HashMa
         "font-size" => {
             styles.insert("fontSize".to_string(), value);
         }
+        "background-color" => {
+            styles.insert("backgroundColor".to_string(), value);
+        }
+        "font-variant" => {
+            styles.insert("fontVariant".to_string(), value);
+        }
+        "hyphenate" => {
+            text_properties_begin_fo_hyphenate(value, styles);
+        }
+        "letter-spacing" => {
+            styles.insert("letterSpacing".to_string(), value);
+        }
+        "text-shadow" => {
+            styles.insert("textShadow".to_string(), value);
+        }
+        "text-transform" => {
+            styles.insert("textTransform".to_string(), value);
+        }
         _ => (),
     };
 }
@@ -595,5 +613,18 @@ fn text_properties_begin_style_underline_color(
     } else {
         // The other valid values are all in hex format
         styles.insert("textDecorationColor".to_string(), value);
+    }
+}
+
+/// Helper for text_properties_begin_fo() to handle hyphenate
+fn text_properties_begin_fo_hyphenate(value: String, styles: &mut HashMap<String, String>) {
+    match value.as_str() {
+        "true" => {
+            styles.insert("hyphens".to_string(), "auto".to_string());
+        }
+        "false" => {
+            styles.insert("hyphens".to_string(), "none".to_string());
+        }
+        _ => (),
     }
 }

--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -597,6 +597,14 @@ fn text_properties_begin_style(
             text_properties_begin_style_underline_color(value, styles);
             false
         }
+        "letter-kerning" => {
+            text_properties_begin_style_letter_kerning(value, styles);
+            false
+        }
+        "text-position" => {
+            text_properties_begin_style_text_position(value, styles);
+            false
+        }
         _ => false,
     }
 }
@@ -647,5 +655,34 @@ fn text_properties_begin_fo_hyphenate(value: String, styles: &mut HashMap<String
             styles.insert("hyphens".to_string(), "none".to_string());
         }
         _ => (),
+    }
+}
+
+/// Helper for text_properties_begin_style() to handle letter kerning
+fn text_properties_begin_style_letter_kerning(value: String, styles: &mut HashMap<String, String>) {
+    match value.as_str() {
+        "true" => {
+            styles.insert("fontKerning".to_string(), "normal".to_string());
+        }
+        "false" => {
+            styles.insert("fontKerning".to_string(), "none".to_string());
+        }
+        _ => (),
+    }
+}
+
+/// Helper for text_properties_begin_style to handle text position (superscript and subscript)
+fn text_properties_begin_style_text_position(value: String, styles: &mut HashMap<String, String>) {
+    let mut split_values = value.split_whitespace();
+    // The first parameter specifies how high/low the text is (mandatory)
+    if let Some(vertical_align) = split_values.next() {
+        styles.insert("verticalAlign".to_string(), vertical_align.to_string());
+    }
+    // The second one specifies how small the text is (optional)
+    if let Some(font_size) = split_values.next() {
+        styles.insert("fontSize".to_string(), font_size.to_string());
+    } else {
+        // The ODT spec does not specify an explicit default, this is what LibreOffice uses
+        styles.insert("fontSize".to_string(), "58%".to_string());
     }
 }


### PR DESCRIPTION
There's quite a few that are troublesome to implement in CSS and/or of limited use, so I've omitted those (details in the Jira issue).

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Parse some more attributes of the text properties tag that can be turned to CSS without too much trouble (since KCSS is not ready yet)

❤️ Thank you for your contribution!
