### PR TITLE
Add support for parsing ODT page layout properties

### DIFF
--- a/server/src/parsers/odt/mod.rs
+++ b/server/src/parsers/odt/mod.rs
@@ -46,6 +46,7 @@ pub struct ODTParser {
     table_row_default_style_names: Vec<Vec<String>>,
     in_list_style: bool,
     list_depth: u32,
+    loaded_page_style: bool,
 }
 
 impl ODTParser {
@@ -71,6 +72,7 @@ impl ODTParser {
             table_row_default_style_names: Vec::new(),
             in_list_style: false,
             list_depth: 0,
+            loaded_page_style: false,
         }
     }
 

--- a/server/src/parsers/odt/text.rs
+++ b/server/src/parsers/odt/text.rs
@@ -498,7 +498,7 @@ pub fn text_properties_begin(attributes: Attributes, map: &mut HashMap<String, S
                 &i.unescaped_value()
                     .unwrap_or_else(|_| std::borrow::Cow::from(vec![])),
             )
-            .unwrap_or("what")
+            .unwrap_or("")
             .to_string();
             if prefix == "fo" {
                 text_properties_begin_fo(local_name, value, map);


### PR DESCRIPTION
Since we are low on time this will only cover the things KDF supports right now. Major things that are left out include headers, footers, columns and background images.

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Parse page layout properties (background colour, borders, margins, page size)

❤️ Thank you for your contribution!
