### PR TITLE
Parse paragraph properties in ODT

### DIFF
--- a/server/src/parsers/odt/mod.rs
+++ b/server/src/parsers/odt/mod.rs
@@ -349,6 +349,12 @@ impl ODTParser {
                             && *self.ensure_children_no_underline.last().unwrap(),
                     );
                 }
+                let mut page_break_after = false;
+                if let Some(_) = child.get_common().styles.remove("_pageBreakAfter") {
+                    // Need to keep track of this in a variable since the element will be moved to
+                    // the document structure
+                    page_break_after = true;
+                }
                 if self.document_hierarchy.is_empty() {
                     self.document_root.content.push(ChildNode::Element(child));
                 } else {
@@ -360,6 +366,9 @@ impl ODTParser {
                         .as_mut()
                         .unwrap()
                         .push(ChildNode::Element(child));
+                }
+                if page_break_after {
+                    self.insert_break(true);
                 }
             } else if prefix == "table" {
                 self.handle_element_end_table(local_name);

--- a/server/src/parsers/odt/styles.rs
+++ b/server/src/parsers/odt/styles.rs
@@ -783,6 +783,15 @@ fn paragraph_properties(attributes: Attributes, styles: &mut HashMap<String, Str
             }
         }
     }
+    if let Some(mut bg_alpha) = styles.remove("_bgAlpha") {
+        bg_alpha.pop(); // Remove the percent sign from the end
+        let mut bg_alpha = 100.0 - bg_alpha.parse::<f64>().unwrap_or(0.0); // Assuming 100% transparency means 0% alpha (can't test this, because LO doesn't even use it)
+        bg_alpha = bg_alpha / 100.0 * 255.0;
+        if let Some(mut bg) = styles.remove("backgroundColor") {
+            bg = format!("{}{:X}", bg, bg_alpha as u32); // Append the alpha as a hex value to the original background
+            styles.insert("backgroundColor".to_string(), bg);
+        }
+    }
 }
 
 /// Helper for paragraph_properties() to handle attributes with "fo" prefix


### PR DESCRIPTION
Only things left out here that I think is worth mentioning is line numbers and background images, everything else doesn’t seem too useful or tricky to implement in CSS (such as customising double borders, joining borders between paragraphs, etc). There’s also tab stops, which is probably a whole other thing to deal with in the future.

### 🚨 Contributor Checklist

 - [x] I have read and followed the [Contributing guide](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md).
 - [x] I am merging into the appropriate branch (usually `develop`).
 - [x] I am merging from a feature/bugfix branch (not my `master` branch).
 - [x] I have run appropriate [linters](https://github.com/sean0x42/kauri/blob/develop/.github/CONTRIBUTING.md#linters) as outlined in the Contributing guide.
 - [x] I have added any major changes to `CHANGELOG.md`.


### Proposed Changes

 - Parse paragraph properties (borders, margins, padding, page breaks before/after, etc)

❤️ Thank you for your contribution!
